### PR TITLE
(rails5) Convert ActionController::Parameters to hash

### DIFF
--- a/lib/wice_grid.rb
+++ b/lib/wice_grid.rb
@@ -216,7 +216,7 @@ module Wice
 
     def process_params  #:nodoc:
       if this_grid_params
-        @status.merge!(this_grid_params)
+        @status.merge!(this_grid_params.to_unsafe_h)
         @status.delete(:export) unless self.export_to_csv_enabled
       end
     end


### PR DESCRIPTION
Removed deprecation warning by using `to_unsafe_h` method.