### PR TITLE
(filter-icons) Remove unnecessary div elements and add styles

### DIFF
--- a/lib/wice/helpers/wice_grid_view_helpers.rb
+++ b/lib/wice/helpers/wice_grid_view_helpers.rb
@@ -547,20 +547,20 @@ module Wice
       if options[:hide_submit_button]
         ''
       else
-        content_tag(:div, content_tag(:i, '', class: 'fa fa-filter'),
+        content_tag(:i, '',
                     title: NlMessage['filter_tooltip'],
                     id:    grid.name + '_submit_grid_icon',
-                    class: 'submit clickable'
+                    class: 'fa fa-filter submit clickable'
         )
       end.html_safe + ' ' +
         if options[:hide_reset_button]
           ''
         else
 
-          content_tag(:div, content_tag(:i, '', class: 'fa fa-table'),
+          content_tag(:i, '',
                       title: NlMessage['reset_filter_tooltip'],
                       id:    grid.name + '_reset_grid_icon',
-                      class: 'reset clickable'
+                      class: 'fa fa-table reset clickable'
           )
         end.html_safe
     end

--- a/vendor/assets/stylesheets/wice_grid.scss
+++ b/vendor/assets/stylesheets/wice_grid.scss
@@ -8,6 +8,12 @@
     }
   }
 
+  .filter_icons {
+    vertical-align: middle;
+    line-height: 1;
+    text-align: center;
+  }
+
   thead th select {
     display: inline-block;
   }


### PR DESCRIPTION
I removed unnecessary `div` elements that were wrapping icons. Also, I aligned icons horizontally and vertically.